### PR TITLE
fix error when dragging items in list widget 4281

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -22,6 +22,9 @@ var $testElement = $('#testelement');
 
 var debounceSave = _.debounce(save, 500);
 
+// Indicate dragging state
+var dragging = false;
+
 enableSwipeSave();
 checkPanelLength();
 
@@ -36,6 +39,7 @@ setTimeout(function() {
     cursor: '-webkit-grabbing; -moz-grabbing;',
     axis: 'y',
     start: function(event, ui) {
+      dragging = true;
       var itemId = $(ui.item).data('id');
       var itemProvider = _.find(linkPromises, function(provider) {
         return provider.id === itemId;
@@ -72,6 +76,8 @@ setTimeout(function() {
         return sortedIds.indexOf(item.id);
       });
       $('.panel').not(ui.item).removeClass('faded');
+
+      dragging = false;
 
       save(false, true);
     },
@@ -198,6 +204,10 @@ $(".tab-content")
     save();
   })
   .on('show.bs.collapse', '.panel-collapse', function() {
+    if (dragging) {
+      return;
+    }
+
     // Get item ID / Get provider / Get item
     var itemID = $(this).parents('.panel').data('id');
     var itemProvider = _.find(linkPromises, function(provider) {


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4281
## Description
We added an additional variable dragging to prevent the creation of an additional provider while dragging an item that caused an error and did not allow saving changes due to the error. This behavior also shows up in widget-list (no images), widget-list (large thumbnails) and list (panels).
## Backward compatibility
This change is fully backward compatible.