### PR TITLE
Placeholder in IE now will display as placeholder not a default value for production version

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -199,7 +199,7 @@
                 <label for="list-item-desc-\{{id}}">Description</label>
               </div>
               <div class="col-sm-8">
-                <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" placeholder="Enter description" rows="2"></textarea>
+                <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" rows="2"></textarea>
               </div>
             </div>
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -418,6 +418,7 @@ function addListItem(data) {
   $accordionContainer.append($newPanel);
   initColorPicker(data);
 
+  $newPanel.find('.form-control.list-item-desc').attr('placeholder', 'Enter description');
   $newPanel.find('.form-control:eq(0)').select();
   $('.form-horizontal').stop().animate({
     scrollTop: $('.tab-content').height()


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5060

## Description
Placeholder in IE now will display as a placeholder, not a default value

## Backward compatibility

This change is fully backward compatible.

## Notes
Same as in this [PR](https://github.com/Fliplet/fliplet-widget-list-small-thumbs/pull/32) so it worked on the production.