### PR TITLE
Title list is centered vertically

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -42,11 +42,13 @@
 }
 
 .list.list-thumb-s ul > li {
-	list-style: none;
+	align-items: center;
 	border-bottom: 1px solid rgba(51,51,51,0.2);
+	display: flex;
+	list-style: none;
+	min-height: 56px;
 	padding: 10px 10px 10px 62px;
 	position: relative;
-	min-height: 56px;
 }
 
 .list.list-thumb-s ul > li .list-swipe-wrapper {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#5367

## Description
Centered vertically with flex.

## Screenshots/screencasts
![small-thumbs](https://user-images.githubusercontent.com/52824207/71984498-a4545d00-3231-11ea-876a-17a483a3baec.PNG)

## Backward compatibility
This change is fully backward compatible.