### PR TITLE
Avoid console error on provider close

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -287,21 +287,21 @@ function initLinkProvider(item) {
 
 function initListener(provider, item) { 
   window.addEventListener('message', function onMessage(event) {
-    // To remove unneeded listener when provider was saved & closed.
+    // Removes listener and enables the cancel button when the provider is saved and closed
     if (event.data === 'save-widget') {
       window.removeEventListener('message', onMessage);
       Fliplet.Widget.toggleCancelButton(true);
     }
 
     if (event.data === 'cancel-button-pressed') {
-        switch (provider) {
-          case 'icon':
-            onIconClose(item);
-            break;
-          case 'image':
-            onImageClose(item);
-            break;
-        }
+      switch (provider) {
+        case 'icon':
+          onIconClose(item);
+          break;
+        case 'image':
+          onImageClose(item);
+          break;
+      }
 
       window.removeEventListener('message', onMessage);
       Fliplet.Widget.toggleCancelButton(true);

--- a/js/interface.js
+++ b/js/interface.js
@@ -287,8 +287,13 @@ function initLinkProvider(item) {
 
 function initListener(provider, item) { 
   window.addEventListener('message', function onMessage(event) {
-    if (event.data === 'cancel-button-pressed' || event.data === 'save-widget') {
-      if (event.data === 'cancel-button-pressed') {
+    // To remove unneeded listener when provider was saved & closed.
+    if (event.data === 'save-widget') {
+      window.removeEventListener('message', onMessage);
+      Fliplet.Widget.toggleCancelButton(true);
+    }
+
+    if (event.data === 'cancel-button-pressed') {
         switch (provider) {
           case 'icon':
             onIconClose(item);
@@ -297,7 +302,6 @@ function initListener(provider, item) {
             onImageClose(item);
             break;
         }
-      }
 
       window.removeEventListener('message', onMessage);
       Fliplet.Widget.toggleCancelButton(true);

--- a/js/interface.js
+++ b/js/interface.js
@@ -287,14 +287,16 @@ function initLinkProvider(item) {
 
 function initListener(provider, item) { 
   window.addEventListener('message', function onMessage(event) {
-    if (event.data === 'cancel-button-pressed') {
-      switch (provider) {
-        case 'icon':
-          onIconClose(item);         
-          break;
-        case 'image':
-          onImageClose(item);
-          break;
+    if (event.data === 'cancel-button-pressed' || event.data === 'save-widget') {
+      if (event.data === 'cancel-button-pressed') {
+        switch (provider) {
+          case 'icon':
+            onIconClose(item);
+            break;
+          case 'image':
+            onImageClose(item);
+            break;
+        }
       }
 
       window.removeEventListener('message', onMessage);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5650#issuecomment-608500527

## Description
Avoid console error on provider close

## Screenshots/screencasts
https://share.getcloudapp.com/E0uqxJvW

## Backward compatibility

This change is fully backward compatible.

## Notes
To avoid console error after we saved icon/image we need to remove listener not only by cancel but also when we save icon/image