### PR TITLE
Allow save icon only when icon was selected

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -299,6 +299,7 @@ function initListener(provider, item) {
 
       window.removeEventListener('message', onMessage);
       Fliplet.Widget.toggleCancelButton(true);
+      Fliplet.Widget.toggleSaveButton(true);
       Fliplet.Widget.resetSaveButtonLabel();
     }
   });
@@ -336,8 +337,13 @@ function initIconProvider(item) {
     data: item,
     // Events fired from the provider
     onEvent: function(event, data) {
-      if (event === 'interface-validate') {
-        Fliplet.Widget.toggleSaveButton(data.isValid === true);
+      switch (event) {
+        case 'interface-validate':
+          Fliplet.Widget.toggleSaveButton(data.isValid === true);
+          break;
+        case 'icon-clicked':
+          Fliplet.Widget.toggleSaveButton(data.isSelected);
+          break;    
       }
     }
   });


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5651

## Description
Allow saving icon only when the icon was selected

## Screenshots/screencasts
https://share.getcloudapp.com/RBudgb4J

## Backward compatibility

This change is fully backward compatible.

## Notes
Works with this [PR](https://github.com/Fliplet/fliplet-widget-icon-selector/pull/2).

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 