### PR TITLE
OD-296 [Fix] Show only saved items after 'swipe to save' 

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -44,7 +44,6 @@
 .list.list-thumb-s ul > li {
 	align-items: center;
 	border-bottom: 1px solid rgba(51,51,51,0.2);
-	display: flex;
 	list-style: none;
 	min-height: 56px;
 	padding: 10px 10px 10px 62px;


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-296 https://weboo.atlassian.net/browse/OD-296
## Description
After saving items using 'Swipe to save' feature show only saved items in user's list.
## Screenshots/screencasts
https://screencast-o-matic.com/watch/crVh6rPlOG
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz
## Notes
Cherry-pick from master.